### PR TITLE
Update the module to 0.6

### DIFF
--- a/examples/quickstart/main.tf
+++ b/examples/quickstart/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     bowtie = {
       source = "bowtieworks/bowtie"
-      version = "0.5.2"
+      version = "0.6.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     bowtie = {
       source  = "bowtieworks/bowtie"
-      version = "0.5.2"
+      version = "0.6.0"
     }
     checkmate = {
       source = "tetratelabs/checkmate"


### PR DESCRIPTION
Upgrading the module in `bowtie-control-plane` to the latest version will ensure compatibility with the API changes made in [provider](https://registry.terraform.io/providers/bowtieworks/bowtie/latest) version 0.6.0.